### PR TITLE
Correction of isAlive game state documentation

### DIFF
--- a/website/Bomberjam.Website/Views/Web/Learn.cshtml
+++ b/website/Bomberjam.Website/Views/Web/Learn.cshtml
@@ -82,7 +82,7 @@
       "bombsLeft": 0,
       "maxBombs": 1,
       "bombRange": 2,
-      "isAlive": true,  // if true, the player has been killed by the sudden death and is no longer in the game
+      "isAlive": true,  // if false, the player has been killed by the sudden death and is no longer in the game
       "respawning": 0, // if positive, the player has been blown by a bomb and is now respawning for this amount of ticks
       "score": 40, // zero of positive number of points
       "timedOut": false,


### PR DESCRIPTION
I would assume `"isAlive": true` means the player has _not_ been killed by the sudden death?